### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Comprehensive MCP server exposing a registry of SeatGeek tools including events, performers, venues, section info, and recommendations as a TypeScript library.
 
+<a href="https://glama.ai/mcp/servers/@PeterShin23/seatgeek-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PeterShin23/seatgeek-mcp/badge" alt="SeatGeek Server MCP server" />
+</a>
+
 ## Demo
 ![seatgeek-mcp-demo](https://github.com/user-attachments/assets/699c41da-9d12-48d0-b413-c532c1397cad)
 


### PR DESCRIPTION
This PR adds a badge for the [SeatGeek MCP Server](https://glama.ai/mcp/servers/@PeterShin23/seatgeek-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@PeterShin23/seatgeek-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PeterShin23/seatgeek-mcp/badge" alt="SeatGeek Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.